### PR TITLE
chore: support configuring commitlint via inputs

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -24,7 +24,7 @@
       "@typescript-eslint/func-call-spacing": ["error", "never"],
       "@typescript-eslint/no-array-constructor": "error",
       "@typescript-eslint/no-empty-interface": "error",
-      "@typescript-eslint/no-explicit-any": "error",
+      "@typescript-eslint/no-explicit-any": "off",
       "@typescript-eslint/no-extraneous-class": "error",
       "@typescript-eslint/no-for-in-array": "error",
       "@typescript-eslint/no-inferrable-types": "error",

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,6 @@ jobs:
             {
               "type-case": [2, "always", "lower-case"],
               "type-empty": [2, "never"],
-              "type-enum": [2, "always", ["feat", "chore"]]
+              "type-enum": [2, "always", ["feat", "fix"]]
             }
       - run: echo "${{ steps.commitMessage.outputs.commitText }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: 'build-test'
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - edited

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: 'build-test'
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - edited
@@ -33,6 +33,6 @@ jobs:
             {
               "type-case": [2, "always", "lower-case"],
               "type-empty": [2, "never"],
-              "type-enum": [2, "always", ["feat", "fix"]]
+              "type-enum": [2, "always", ["feat", "fix", "chore"]]
             }
       - run: echo "${{ steps.commitMessage.outputs.commitText }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,4 +28,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         id: commitMessage
+        with:
+          config: |
+            {
+              "type-case": [2, "always", "lower-case"],
+              "type-empty": [2, "never"],
+              "type-enum": [2, "always", ["feat", "chore"]]
+            }
       - run: echo "${{ steps.commitMessage.outputs.commitText }}"

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,10 @@
 name: 'Action Lint PR'
 description: 'Lint PR title and description'
 author: 'finn@deeplay.io'
+inputs:
+  config:
+    description: 'Commitlint config JSON'
+    required: false
 outputs:
   commitText:
     description: Text generated for squash commit message

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,8 +19,8 @@ async function run(): Promise<void> {
     if (configJson) {
       try {
         config = JSON.parse(core.getInput('config'))
-      } catch (err: any) {
-        throw new Error(`Failed to parse config json: ${err.message}`)
+      } catch (err) {
+        throw new Error(`Failed to parse config json: ${(err as any).message}`)
       }
     } else {
       config = {
@@ -56,7 +56,7 @@ async function run(): Promise<void> {
     await validateCommitMessage(commitText, config)
     core.debug(commitText)
     core.setOutput('commitText', commitText)
-  } catch (error: any) {
+  } catch (error) {
     core.setFailed(error.message)
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,7 +14,7 @@ async function run(): Promise<void> {
   try {
     const configJson = core.getInput('config')
 
-    core.debug('config', configJson)
+    core.debug(`config: ${configJson}`)
 
     let config: QualifiedRules
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,7 +14,7 @@ async function run(): Promise<void> {
   try {
     const configJson = core.getInput('config')
 
-    core.debug(`config: ${configJson}`)
+    core.debug(`config: ${configJson} `)
 
     let config: QualifiedRules
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,7 +19,7 @@ async function run(): Promise<void> {
     if (configJson) {
       try {
         config = JSON.parse(core.getInput('config'))
-      } catch (err) {
+      } catch (err: any) {
         throw new Error(`Failed to parse config json: ${err.message}`)
       }
     } else {
@@ -56,7 +56,7 @@ async function run(): Promise<void> {
     await validateCommitMessage(commitText, config)
     core.debug(commitText)
     core.setOutput('commitText', commitText)
-  } catch (error) {
+  } catch (error: any) {
     core.setFailed(error.message)
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,8 +19,8 @@ async function run(): Promise<void> {
     if (configJson) {
       try {
         config = JSON.parse(core.getInput('config'))
-      } catch (err) {
-        throw new Error(`Failed to parse config json: ${(err as any).message}`)
+      } catch (err: any) {
+        throw new Error(`Failed to parse config json: ${err.message}`)
       }
     } else {
       config = {
@@ -56,7 +56,7 @@ async function run(): Promise<void> {
     await validateCommitMessage(commitText, config)
     core.debug(commitText)
     core.setOutput('commitText', commitText)
-  } catch (error) {
+  } catch (error: any) {
     core.setFailed(error.message)
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import * as core from '@actions/core'
 import * as github from '@actions/github'
 import lint from '@commitlint/lint'
+import {QualifiedRules} from '@commitlint/types'
 import {getCommitText} from './getCommitText'
 
 const githubToken = process.env.GITHUB_TOKEN
@@ -11,6 +12,24 @@ async function run(): Promise<void> {
   }
 
   try {
+    const configJson = core.getInput('config')
+
+    let config: QualifiedRules
+
+    if (configJson) {
+      try {
+        config = JSON.parse(core.getInput('config'))
+      } catch (err) {
+        throw new Error(`Failed to parse config json: ${err.message}`)
+      }
+    } else {
+      config = {
+        'type-case': [2, 'always', 'lower-case'],
+        'type-empty': [2, 'never'],
+        'type-enum': [2, 'always', ['feat', 'chore']]
+      }
+    }
+
     const client = github.getOctokit(githubToken)
 
     const contextPullRequest = github.context.payload.pull_request
@@ -34,7 +53,7 @@ async function run(): Promise<void> {
     })
 
     const commitText = getCommitText(pullRequest.body, pullRequest.title)
-    await validateCommitMessage(commitText)
+    await validateCommitMessage(commitText, config)
     core.debug(commitText)
     core.setOutput('commitText', commitText)
   } catch (error) {
@@ -42,15 +61,11 @@ async function run(): Promise<void> {
   }
 }
 
-async function validateCommitMessage(commitMessage: string): Promise<void> {
-  // TODO: get commitlint config from input
-  // Currently blocked by @commitlint/load issue on loading configuration
-  // Similar issue – https://github.com/conventional-changelog/commitlint/issues/613
-  const result = await lint(commitMessage, {
-    'type-case': [2, 'always', 'lower-case'],
-    'type-empty': [2, 'never'],
-    'type-enum': [2, 'always', ['feat', 'chore']]
-  })
+async function validateCommitMessage(
+  commitMessage: string,
+  config: QualifiedRules
+): Promise<void> {
+  const result = await lint(commitMessage, config)
 
   if (!result.valid) {
     throw new Error(

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,8 @@ async function run(): Promise<void> {
   try {
     const configJson = core.getInput('config')
 
+    core.debug('config', configJson)
+
     let config: QualifiedRules
 
     if (configJson) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,8 +14,6 @@ async function run(): Promise<void> {
   try {
     const configJson = core.getInput('config')
 
-    core.debug(`config: ${configJson} `)
-
     let config: QualifiedRules
 
     if (configJson) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,5 +8,6 @@
     "noImplicitAny": true,                    /* Raise error on expressions and declarations with an implied 'any' type. */
     "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
   },
+  "include": ["src"],
   "exclude": ["node_modules", "**/*.test.ts"]
 }


### PR DESCRIPTION
This PR adds support for configuring commitlint via JSON string passed to action inputs.

```yaml
with:
  config: |
    {
      "type-case": [2, "always", "lower-case"],
      "type-empty": [2, "never"],
      "type-enum": [2, "always", ["feat", "fix", "chore"]]
    }
```